### PR TITLE
[FEAT] 이메일 중복체크 및 인증번호 발송, 인증번호 확인, 재인증

### DIFF
--- a/src/api/checkEmail.ts
+++ b/src/api/checkEmail.ts
@@ -9,3 +9,19 @@ export const checkEmail = async (userEmail: string) => {
   );
   return response;
 };
+
+export const checkEmailAuth = async (data: {
+  userEmail: string;
+  userEmailAuth: string;
+}) => {
+  const response = await axios.post(
+    `${BASE_API_URL}/v1/auth/checkEmailAuth`,
+    data,
+    {
+      headers: {
+        'content-type': 'application/json',
+      },
+    },
+  );
+  return response;
+};

--- a/src/api/checkEmail.ts
+++ b/src/api/checkEmail.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { BASE_API_URL } from '@/data/constants';
+
+export const checkEmail = async (userEmail: string) => {
+  const response = await axios.post(
+    `${BASE_API_URL}/v1/auth/checkEmail`,
+    userEmail,
+    { headers: { 'content-type': 'application/json' } },
+  );
+  return response;
+};

--- a/src/api/cloudinary.ts
+++ b/src/api/cloudinary.ts
@@ -11,10 +11,10 @@ export const handleUpload = async (file: string | Blob) => {
     return null;
   }
 
-  const res = await axios.post(
+  const response = await axios.post(
     `https://api.cloudinary.com/v1_1/${cloudinaryName}/image/upload/`,
     formData,
   );
 
-  return res;
+  return response;
 };

--- a/src/api/signup.ts
+++ b/src/api/signup.ts
@@ -11,17 +11,12 @@ interface valuseType {
   userName: string;
 }
 
-export const signUp = async (values: valuseType) => {
+export const signup = async (values: valuseType) => {
   const { confirm_password, ...otherData } = values;
 
-  const res = await axios.post(
+  const response = await axios.post(
     `${BASE_API_URL}/v1/auth/signup`,
-    JSON.stringify(otherData),
-    {
-      headers: {
-        'content-type': 'application/json',
-      },
-    },
+    otherData,
   );
-  return res;
+  return response;
 };

--- a/src/api/verification.ts
+++ b/src/api/verification.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { BASE_API_URL } from '@/data/constants';
+
+export const verificationEmail = async (userEmail: string) => {
+  const response = await axios.post(
+    `${BASE_API_URL}/v1/auth/sendEmail`,
+    userEmail,
+    { headers: { 'content-type': 'application/json' } },
+  );
+  return response;
+};

--- a/src/page/signup/index.tsx
+++ b/src/page/signup/index.tsx
@@ -275,7 +275,7 @@ export default function SingUp() {
     setIsEmailCheck(false);
     setVerification(false);
     setEmailVerified(false);
-    setReSend(true);
+    setReSend(false);
   };
 
   return (

--- a/src/page/signup/index.tsx
+++ b/src/page/signup/index.tsx
@@ -342,7 +342,7 @@ export default function SingUp() {
                     <Button
                       type="primary"
                       onClick={handleReSend}
-                      disabled={reSend}
+                      disabled={!reSend}
                     >
                       재발송
                     </Button>


### PR DESCRIPTION
# 📝 작업내용
<img width="1262" alt="image" src="https://github.com/KDT5-MINI-TEAM11/client/assets/115094069/34a1be8e-3bba-4774-8650-efa4ea86bad8">

- 이메일 중복 체크 (이미 가입된 이메일이면 "이미 가입 된 이메일 입니다." 메세지 출력)
- 이메일 인증번호 발송 
- 인증번호 확인
- 재인증 (다른 이메일 사용할 시에)

# 관련 이슈
closed #18 

# 공유사항
- src/data/api 폴더에 checkEmail.ts, verification.ts 파일 추가
- checkEmail.ts에 이메일 중복체크 및 이메일 인증번호 발송 api 엔드포인트 같이 사용 
- 이메일 인증번호 발송 시에 response에 인증번호 포함되어있는 부분 백엔드에서 수정 예정 및 휴대폰 중복 체크 엔드포인트가 있는데 그 부분 없애고 회원가입 시에 중복된 번호가 있으면 response에 에러코드와 중복된 연락처라고 메세지 반환처리해서 클라이언트에서 메세지 출력되게 할 예정입니다. 아직 백엔드 측에서 수정이 안되어있어서 수정되면 바로 변경하겠습니다.