### PR TITLE
[FEAT] 현재 달력의 년월 동적으로 가져옴

### DIFF
--- a/src/page/home/calendar.tsx
+++ b/src/page/home/calendar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, LegacyRef } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
@@ -20,6 +20,15 @@ export default function Calendar({ isSignedin }: propsType) {
   // 데이터로 받아올 events를 상태관리
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const [events, setEvents] = useState([]);
+  // 달력의 현재 년도 상태관리
+  const [year, setYear] = useState(new Date().getFullYear());
+  // 달력의 현재 월 상태관리
+  const [month, setMonth] = useState(new Date().getMonth() + 1);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const calendarRef = useRef(null);
+  /*   // 로그아웃 시에 이벤트를 비워서 리렌더링 시키기 위해 사용
+  const clearEvents = () => setEvents([]); */
 
   // 데이터 변경시에 화면 리렌더링 되게
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -28,9 +37,9 @@ export default function Calendar({ isSignedin }: propsType) {
       // getAccessTokenFromCookie를 이용해서 쿠키에 저장된 accessToken을 가져옴
       const accessToken = getAccessTokenFromCookie();
       // accessToken, 년월 매개변수로 전달 (년월 전달하는 방식은 추후에 변경)
-      const response = await scheduleList(accessToken, 2023, 8);
-
-      const responseData = response.data.response; // 실제 응답 데이터 추출
+      const response = await scheduleList(accessToken, year, month);
+      // 실제 응답 데이터 추출
+      const responseData = response.data.response;
       // response data를 가져오는데 그 내부에 있는 response라는 배열 데이터를 각각의 요소를
       // 아래의 형태의 객체로 변환해서 events 변수에 저장, setEvents에 전달
       const events = responseData.map((item: ScheduleItem) => {
@@ -44,7 +53,11 @@ export default function Calendar({ isSignedin }: propsType) {
       setEvents(events);
     };
     schedule();
-  }, [isSignedin]);
+  }, [isSignedin, year, month]);
+
+  /*   useEffect(() => {
+    clearEvents();
+  }, [isSignedin]); */
 
   // scheduleType에 따른 색상 변환
   const getColorFromState = (scheduleType: string) => {
@@ -64,6 +77,13 @@ export default function Calendar({ isSignedin }: propsType) {
     return args.date.getDate();
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDateSet = (info: any) => {
+    let date = info.view.currentStart;
+    setYear(date.getFullYear());
+    setMonth(date.getMonth() + 1);
+  };
+
   return (
     <>
       <FullCalendar
@@ -72,9 +92,11 @@ export default function Calendar({ isSignedin }: propsType) {
         dayMaxEvents={true}
         events={events} // 연차 당직 달력에 표시
         height={'800px'}
+        datesSet={handleDateSet}
         dateClick={handleDateClick} // 누르면 당일 날짜 콘솔에 찍힘
         locale={'ko'} // 지역
         dayCellContent={renderDayCellContent} // '일' 문자 렌더링 변경
+        ref={calendarRef}
       />
     </>
   );

--- a/src/page/home/index.tsx
+++ b/src/page/home/index.tsx
@@ -143,7 +143,7 @@ export default function Home() {
               overflow: 'auto',
             }}
           >
-            {/* 로그인 상태를 확인하기 위해서 isSignedin를 Calendar컴포넌트에 props로 전달 */}
+            {/* 로그인 상태를 확인하기 위해서 accessToken을 boolean 데이터 형식으로 변환해서 Calendar컴포넌트에 props로 전달 */}
             <Calendar isSignedin={!!accessToken} />
           </Content>
         </Layout>


### PR DESCRIPTION
# 📝 작업내용


-달력 월 변경 시에 동적으로 현재 년월 가져와서 scheduleList에 매개변수로 전달

# 관련 이슈
closed #27

# 공유사항
- 달력 로그아웃 시 달력에 기입된 이벤트 전부 정리할 건지, 아니면 로그아웃되면 자동으로 블러 처리되니깐 놔둘건지



