### PR TITLE
[FIX]달력 이벤트 렌더링 되는 부분 이슈 확인

### DIFF
--- a/src/page/home/calendar.tsx
+++ b/src/page/home/calendar.tsx
@@ -90,11 +90,6 @@ export default function Calendar({ isSignedin, year, setYear }: propsType) {
   // scheduleType에 따른 색상 변환
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleDateClick = (arg: any) => {
-    console.log(arg.date.toLocaleString());
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const renderDayCellContent = (args: any) => {
     // '일' 문자 제거
     return args.date.getDate();
@@ -105,6 +100,22 @@ export default function Calendar({ isSignedin, year, setYear }: propsType) {
     const date = info.view.currentStart;
     setYear(date.getFullYear());
     setMonth(date.getMonth() + 1);
+  };
+
+  /* 
+  const formatDateToKorean = (date: Date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; 
+    const day = date.getDate();
+
+    return `${year}년 ${month}월 ${day}일`;
+  }; */
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleEventClick = (info: any) => {
+    console.log(info.event.title);
+    console.log(info.event.start);
+    console.log(info.event.end);
   };
 
   return (
@@ -124,10 +135,10 @@ export default function Calendar({ isSignedin, year, setYear }: propsType) {
         events={events} // 연차 당직 달력에 표시
         height={'800px'}
         datesSet={handleDateSet}
-        dateClick={handleDateClick} // 누르면 당일 날짜 콘솔에 찍힘
         locale={'ko'} // 지역
         dayCellContent={renderDayCellContent} // '일' 문자 렌더링 변경
         ref={calendarRef}
+        eventClick={handleEventClick}
       />
     </>
   );


### PR DESCRIPTION



# 📝 작업내용
<img width="1262" alt="image" src="https://github.com/KDT5-MINI-TEAM11/client/assets/115094069/cccd364d-bb56-461d-89b5-40f623a70508">
<img width="1262" alt="image" src="https://github.com/KDT5-MINI-TEAM11/client/assets/115094069/c01f13e7-db3e-4f77-8d44-3b34a8c32f21">


-연차 선택 시 달력에 연차 이벤트의 endDate가 하루 전으로 표기되는 이슈

# 관련 이슈
#35 

# 공유사항
```
  const handleDatePicker = (value: DatePickerProps['value']) => {
    const startDate = dayjs(value).format('YYYY-MM-DD');
    setScheduleInput((prev) => ({
      ...prev,
      startDate: dayjs(startDate).format('YYYY-MM-DD'),
      endDate: dayjs(startDate).format('YYYY-MM-DD'),
    }));
  };
```
`endDate: dayjs(startDate).format('YYYY-MM-DD'),` 이 부분에 23:59:59 또는 23:59:00 추가하면 해결이 되지않을까 싶습니다.

스키마 상에는 시간 분으로 데이터가 전달되지 않기 때문에 다같이 이야기를 해봐야할거 같습니다.

